### PR TITLE
require pyOpenSSL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Twisted
 ConfigObj
+pyOpenSSL


### PR DESCRIPTION
```
  File "C:\Users\Michael\AppData\Local\Programs\Python\Python36-32\lib\site-packages\twisted\internet\ssl.py", line 58, in <module>
    from OpenSSL import SSL
ModuleNotFoundError: No module named 'OpenSSL'
```